### PR TITLE
Replace rustc_serialize with serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,7 @@ default = []
 
 [dependencies]
 libc = "*"
-rustc-serialize = "*"
+serde = "1.0.8"
+serde_json = "1.0.2"
+serde_derive = "1.0.8"
 clippy = {version = "0.0.61", optional = true}

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,7 +1,11 @@
-#[macro_use] extern crate r2pipe;
+extern crate r2pipe;
+extern crate serde_json;
+
 use r2pipe::R2Pipe;
 use r2pipe::R2PipeSpawnOptions;
 use std::process;
+
+use serde_json::Value;
 
 fn test_trim() {
     let mut ns = R2Pipe::spawn("/bin/ls".to_owned(), None).unwrap();
@@ -29,15 +33,9 @@ fn main() {
     println!("{}", r2p.cmd("?e Hello World").unwrap());
 
     let json = r2p.cmdj("ij").unwrap();
-    println!("{}", json.pretty());
-    println!("ARCH {}", json.find_path(&["bin", "arch"]).unwrap());
-
-    // println!("BITS 0x{:x}",json.find_path(&["bin","bits"]).unwrap().as_u64().unwrap());
-    if let Some(bits) = json.find_path(&["bin", "bits"]) {
-        if let Some(n_bits) = bits.as_u64() {
-            println!("BITS 0x{:x}", n_bits);
-        }
-    }
+    println!("{}", serde_json::to_string_pretty(&json).unwrap());
+    println!("ARCH {}", json["bin"]["arch"]);
+    println!("BITS {}", json["bin"]["bits"]);
     println!("Disasm:\n{}", r2p.cmd("pd 20").unwrap());
     println!("Hexdump:\n{}", r2p.cmd("px 64").unwrap());
     r2p.close();

--- a/examples/quit.rs
+++ b/examples/quit.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate r2pipe;
 use r2pipe::R2Pipe;
 

--- a/examples/r2_example.rs
+++ b/examples/r2_example.rs
@@ -1,14 +1,13 @@
-#[macro_use] extern crate r2pipe;
-extern crate rustc_serialize;
+extern crate r2pipe;
+extern crate serde_json;
 
 use r2pipe::r2::R2;
-use rustc_serialize::json;
 
 fn main() {
     let path = "/Users/sushant/projects/radare/rust/radeco-lib/ct1_sccp_ex.o";
     let mut r2 = R2::new(Some(path)).expect("Failed to spawn r2");
     r2.init();
-    println!("{}", json::encode(&r2.fn_list().expect("Failed to get Function data")).expect("Serialize failed"));
+    println!("{}", serde_json::to_string(&r2.fn_list().expect("Failed to get Function data")).expect("Serialize failed"));
     //println!("{:#?}", r2.sections().expect("Failed to get section data"));
     println!("{:#?}", r2.fn_list().expect("Failed to get function data"));
     //println!("{:#?}", r2.flag_info().expect("Failed to get flag data"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,8 @@
 //!     let mut r2p = open_pipe!(path).unwrap();
 //!     println!("{}", r2p.cmd("?e Hello World").unwrap());
 //!     if let Ok(json) = r2p.cmdj("ij") {
-//!         println!("{}", json);
-//!         //println!("ARCH {}", json.find_path(&["bin","arch"]).unwrap());
+//!         println!("{}", serde_json::to_string_pretty(&json).unwrap());
+//!         println!("ARCH {}", json["bin"]["arch"]);
 //!     }
 //!     r2p.close();
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,14 +31,15 @@
 //! ```no_run
 //! #[macro_use]
 //! extern crate r2pipe;
+//! extern crate serde_json;
 //! use r2pipe::R2Pipe;
 //! fn main() {
 //!     let path = Some("/bin/ls".to_owned());
 //!     let mut r2p = open_pipe!(path).unwrap();
 //!     println!("{}", r2p.cmd("?e Hello World").unwrap());
 //!     if let Ok(json) = r2p.cmdj("ij") {
-//!         println!("{}", json.pretty());
-//!         println!("ARCH {}", json.find_path(&["bin","arch"]).unwrap());
+//!         println!("{}", json);
+//!         //println!("ARCH {}", json.find_path(&["bin","arch"]).unwrap());
 //!     }
 //!     r2p.close();
 //! }
@@ -51,7 +52,10 @@
 #![cfg_attr(feature="clippy", plugin(clippy))]
 
 extern crate libc;
-extern crate rustc_serialize;
+extern crate serde;
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
 
 #[macro_use]
 pub mod r2pipe;

--- a/src/r2.rs
+++ b/src/r2.rs
@@ -23,6 +23,7 @@
 use r2pipe::R2Pipe;
 use serde_json;
 use serde_json::Error;
+use serde_json::Value;
 
 use super::structs::*;
 
@@ -127,13 +128,14 @@ impl R2 {
         res
     }
 
-    pub fn recv_json(&mut self) -> String {
+    pub fn recv_json(&mut self) -> Value {
         let mut res = self.recv().replace("\n", "");
         if res.is_empty() {
             res = "{}".to_owned();
         }
 
-        res
+        // TODO: this should probably return a Result<Value, Error>
+        serde_json::from_str(&res).unwrap()
     }
 
     pub fn flush(&mut self) {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -6,45 +6,8 @@
 // except according to those terms.
 
 //! Basic structs for JSON encoding and decoding.
-use rustc_serialize::{Decodable, Decoder, Encoder, Encodable};
 
-macro_rules! impl_encode_decode {
-    (for $st:ident, mapping { $($internal:ident: $external:expr),* }) => {
-        impl Decodable for $st {
-            fn decode<D: Decoder>(d: &mut D) -> Result<$st, D::Error> {
-                d.read_struct("root", 0, |dd| {
-                        let decoded = $st {
-                            $(
-                                $internal: dd.read_struct_field($external, 0, |d| Decodable::decode(d)).ok(),
-                            )*
-                        };
-                        Ok(decoded)
-                    })
-            }
-        }
-
-        impl Encodable for $st {
-            fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-                let mut i = 0;
-                s.emit_struct("root", 1, |s| {
-                    $(
-                        try!(s.emit_struct_field($external, i, |s| self.$internal.encode(s)));
-                        i = 1;
-                     )*
-                        Ok(())
-                })
-            }
-        }
-    }
-}
-
-impl_encode_decode!(for LOpInfo, mapping {   esil: "esil",
-                                           offset: "offset",
-                                           opcode: "opcode",
-                                           optype: "type",
-                                             size: "size" });
-
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LOpInfo {
     pub esil: Option<String>,
     pub offset: Option<u64>,
@@ -53,27 +16,27 @@ pub struct LOpInfo {
     pub size: Option<u64>,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LFunctionInfo {
     pub addr: Option<u64>,
     pub name: Option<String>,
     pub ops: Option<Vec<LOpInfo>>,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LRegInfo {
     pub alias_info: Vec<LAliasInfo>,
     pub reg_info: Vec<LRegProfile>,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LAliasInfo {
     pub reg: String,
     pub role: u64,
     pub role_str: String,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LRegProfile {
     pub name: String,
     pub offset: usize,
@@ -81,42 +44,31 @@ pub struct LRegProfile {
     pub type_str: String,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LFlagInfo {
     pub offset: u64,
     pub name: String,
     pub size: u64,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LBinInfo {
     pub core: Option<LCoreInfo>,
     pub bin: Option<LBin>,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LCoreInfo {
     pub file: Option<String>,
     pub size: Option<usize>,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LBin {
     pub arch: Option<String>,
 }
 
-impl_encode_decode!(for FunctionInfo, mapping {  callrefs: "callrefs",
-                                                 calltype: "calltype",
-                                                codexrefs: "codexrefs",
-                                                 datarefs: "datarefs",
-                                                dataxrefs: "dataxrefs",
-                                                     name: "name",
-                                                   offset: "offset",
-                                                   realsz: "realsz",
-                                                     size: "size",
-                                                    ftype: "type",
-                                                    locals: "locals" });
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FunctionInfo {
     pub callrefs: Option<Vec<LCallInfo>>,
     pub calltype: Option<String>,
@@ -131,15 +83,14 @@ pub struct FunctionInfo {
     pub locals: Option<Vec<LVarInfo>>,
 }
 
-impl_encode_decode!(for LCallInfo, mapping { target: "addr", call_type: "type", source: "at"});
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LCallInfo {
     pub target: Option<u64>,
     pub call_type: Option<String>,
     pub source: Option<u64>,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LSectionInfo {
     pub flags: Option<String>,
     pub name: Option<String>,
@@ -149,15 +100,7 @@ pub struct LSectionInfo {
     pub vsize: Option<u64>,
 }
 
-impl_encode_decode!(for LStringInfo, mapping {  length: "length",
-                                               ordinal: "ordinal",
-                                                 paddr: "paddr",
-                                               section: "section",
-                                                  size: "size",
-                                                string: "string",
-                                                 vaddr: "vaddr",
-                                                 stype: "type" });
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LStringInfo {
     pub length: Option<u64>,
     pub ordinal: Option<u64>,
@@ -169,11 +112,7 @@ pub struct LStringInfo {
     pub stype: Option<String>,
 }
 
-impl_encode_decode!(for LVarInfo, mapping { name: "name",
-                                            kind: "kind",
-                                            vtype: "type",
-                                            reference: "ref"});
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LVarInfo {
     pub name: Option<String>,
     pub kind: Option<String>,
@@ -181,7 +120,7 @@ pub struct LVarInfo {
     pub reference: Option<LVarRef>,
 }
 
-#[derive(RustcDecodable, RustcEncodable, Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LVarRef {
     pub base: Option<String>,
     pub offset: Option<i64>,


### PR DESCRIPTION
The rustc_serialize crate for serialization has been deprecated in favor
of serde.