### PR TITLE
Shave off some code by making the pipe a dyn

### DIFF
--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -59,13 +59,7 @@ pub struct R2PipeSpawnOptions {
 }
 
 /// Provides abstraction between the three invocation methods.
-pub enum R2Pipe {
-    Pipe(R2PipeSpawn),
-    Lang(R2PipeLang),
-    Tcp(R2PipeTcp),
-    Http(R2PipeHttp),
-}
-
+pub struct R2Pipe(Box<dyn Pipe>);
 pub trait Pipe {
     fn cmd(&mut self, cmd: &str) -> Result<String>;
     fn cmdj(&mut self, cmd: &str) -> Result<Value>;
@@ -126,31 +120,23 @@ impl R2Pipe {
                 write: File::from_raw_fd(d_out),
             }
         };
-        Ok(R2Pipe::Lang(res))
+        Ok(R2Pipe(Box::new(res)))
     }
 
     #[cfg(windows)]
     pub fn open() -> Result<R2Pipe> {
         unimplemented!()
     }
-    fn get_pipe(&mut self) -> &'_ mut dyn Pipe {
-        match *self {
-            R2Pipe::Pipe(ref mut x) => x,
-            R2Pipe::Lang(ref mut x) => x,
-            R2Pipe::Tcp(ref mut x) => x,
-            R2Pipe::Http(ref mut x) => x,
-        }
-    }
     pub fn cmd(&mut self, cmd: &str) -> Result<String> {
-        self.get_pipe().cmd(cmd.trim())
+        self.0.cmd(cmd.trim())
     }
 
     pub fn cmdj(&mut self, cmd: &str) -> Result<Value> {
-        self.get_pipe().cmdj(cmd.trim())
+        self.0.cmdj(cmd.trim())
     }
 
     pub fn close(&mut self) {
-        self.get_pipe().close();
+        self.0.close();
     }
 
     pub fn in_session() -> Option<(i32, i32)> {
@@ -207,7 +193,7 @@ impl R2Pipe {
             child: Some(child),
         };
 
-        Ok(R2Pipe::Pipe(res))
+        Ok(R2Pipe(Box::new(res)))
     }
 
     /// Creates a new R2PipeTcp
@@ -215,14 +201,14 @@ impl R2Pipe {
         // use `connect` to figure out which socket address works
         let stream = TcpStream::connect(addr)?;
         let addr = stream.peer_addr()?;
-        Ok(R2Pipe::Tcp(R2PipeTcp { socket_addr: addr }))
+        Ok(R2Pipe(Box::new(R2PipeTcp { socket_addr: addr })))
     }
 
     /// Creates a new R2PipeHttp
     pub fn http(host: &str) -> R2Pipe {
-        R2Pipe::Http(R2PipeHttp {
+        R2Pipe(Box::new(R2PipeHttp {
             host: host.to_string(),
-        })
+        }))
     }
 
     /// Creates new pipe threads


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**
This pr attempts to simplify the r2pipe.rs code by replacing all the variants of the of `R2pipe` with a single `Box` that contains  a `dyn Pipe` (`pub struct R2Pipe(Box<dyn Pipe>);`). This removes the need for the `get_pipe` method and shaves off about 14 lines of code. On the other hand, This PR may or may not break some code because the `R2Pipe` enum was public (and so is the new `R2pipe` struct) so the variants were public too.
If this PR is going to cause problems, it would be with `R2PipeSpawn` because as far as I can tell it is the only struct that has an impl block not for the Pipe trait.